### PR TITLE
Update containerfile to more recent Fedora

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:35
+FROM registry.fedoraproject.org/fedora:38
 
 LABEL \
     name="repotracker" \


### PR DESCRIPTION
Because Fedora-35 has issues with COPR repos.
The COPR for python-rhsmg no longer has Fedora-35:
  https://copr-be.cloud.fedoraproject.org/results/mikeb/python-rhmsg/

We can use Fedora 36 ~ 38

This updates to 38